### PR TITLE
fix tilde markdown deletion in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The two tables below lists all of the built-in semantic types and their correspo
 |:--|:--------------|:----|:----|:--------|:----------------------------|:--------|:-----|:--------------------------|
 |ground| null| _ | | nil |"\_" |nil| null when not key, else "~\_" | null when not key, else "~\_" |
 |ground| string| s | | "string" | | String | String | String |
-|ground| boolean |?| |  boolean| "t" or "f"| Boolean | Boolean when not key, else "~?t" or "~?f" | Boolean when not key, else "~?t" or "~?f"|
+|ground| boolean |?| |  boolean| "t" or "f"| Boolean | Boolean when not key, else "\~?t" or "\~?f" | Boolean when not key, else "\~?t" or "\~?f"|
 |ground| integer, signed 64 bit| i| | integer | "123"| smallest int that holds value | < 2^53 and not key, JSON number; else "~i1234..." | < 2^53 and not key, JSON number; else "~i1234..."|
 |ground|floating pt decimal| d| |  floating pt number | "123.456" | smallest float that matches precision | JSON number when not key, else "~d123.456" | JSON number when not key, else "~d123.456"|
 |ground| bytes| b | | base64 encoded bytes ([RFC 4648](http://www.ietf.org/rfc/rfc4648.txt))| "base64 encoded bytes"|  "~bbase64" | "~bbase64" | "~bbase64" |
@@ -88,7 +88,7 @@ The two tables below lists all of the built-in semantic types and their correspo
 |extension| char |c| s| "c"| | "~cc" | "~cc"| "~cc" |
 |extension| quoted value| ' | | value| NA|	["~#'", value] | ["~#'", value] | {"~#'" : value } |
 |extension| special numbers |z| s| "NaN", "INF", "-INF"| | "~zrep" | "~zrep"| "~zrep" |
-|*extension*|*Scalar extension type* | *X*| *specify or s* | *"arep" or arep*|  *"arep"* | *"~Xarep" or ["~#X", arep]*| *"~Xarep" or ["~#X", arep]* | *"~Xarep" or {"~#X": arep}* |
+|*extension*|*Scalar extension type* | *X*| *specify or s* | *"arep" or arep*|  *"arep"* | *"\~Xarep" or ["\~#X", arep]*| *"\~Xarep" or ["\~#X", arep]* | *"\~Xarep" or {"\~#X": arep}* |
 
 **Composite Types**
 


### PR DESCRIPTION
![Screen Shot 2019-10-31 at 1 08 21 PM](https://user-images.githubusercontent.com/338607/67969378-8e963c00-fbdf-11e9-9b69-aa079684070a.png)

instead of

![Screen Shot 2019-10-31 at 1 08 31 PM](https://user-images.githubusercontent.com/338607/67969389-93f38680-fbdf-11e9-8264-264c250d398f.png)
